### PR TITLE
Fix NullReferenceException when changing value after Dispose()

### DIFF
--- a/Source/RxVar.cs
+++ b/Source/RxVar.cs
@@ -377,12 +377,8 @@ namespace Rx.Net.Plus
         protected override void OnDisposing(bool isDisposing)
         {
             base.OnDisposing(isDisposing);
-
-            if (_subject != null)
-            {
-                _subject.Dispose();
-                _subject = null;
-            }
+            
+            _subject?.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
Rx Subject handles subscriptions even after dispose was called.
If you set it to null, you throw exception.
If you want to throw exception - please throw a relevant exception (ObjectDisposedException - with type name printed for example)